### PR TITLE
Remove deprecated 'bottle :unneeded'

### DIFF
--- a/Formula/powershell-daily.rb
+++ b/Formula/powershell-daily.rb
@@ -15,7 +15,6 @@ class PowershellDaily < Formula
   # must be lower-case
   sha256 "5738268b50501b60c52fff7f5089294728070e472a6dea3687f7a1f4ff589de7"
   version_scheme 1
-  bottle :unneeded
 
   # .NET Core 3.1 requires High Sierra - https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31
   depends_on macos: :high_sierra

--- a/Formula/powershell-lts.rb
+++ b/Formula/powershell-lts.rb
@@ -15,7 +15,6 @@ class PowershellLts < Formula
   # must be lower-case
   sha256 "48b19a455f3aaa2a385616cf36f21453aff536d70209be5be9b88cd4838c820f"
   version_scheme 1
-  bottle :unneeded
 
   # .NET Core 3.1 requires High Sierra - https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31
   depends_on macos: :high_sierra

--- a/Formula/powershell-preview.rb
+++ b/Formula/powershell-preview.rb
@@ -20,8 +20,6 @@ class PowershellPreview < Formula
     url :head
   end
 
-  bottle :unneeded
-
   # .NET Core 3.1 requires High Sierra - https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31
   depends_on macos: :high_sierra
 

--- a/Formula/powershell.rb
+++ b/Formula/powershell.rb
@@ -15,7 +15,6 @@ class Powershell < Formula
   # must be lower-case
   sha256 "0f55f67d48534671fd07017680fe55c48949a748009fef11b01585c47e6eb398"
   version_scheme 1
-  bottle :unneeded
 
   # .NET Core 3.1 requires High Sierra - https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31
   depends_on macos: :high_sierra


### PR DESCRIPTION
The formula parameter bottle :unneeded has been deprecated. There is no replacement for it. 

Homebrew/brew@f65d525
Homebrew/brew#11239