### PR TITLE
Update powershell formula to version 7.2.2

### DIFF
--- a/Formula/powershell.rb
+++ b/Formula/powershell.rb
@@ -10,10 +10,10 @@ class Powershell < Formula
   desc "Formula to install PowerShell"
   homepage "https://github.com/powershell/powershell"
 
-  @arm64url = "https://github.com/PowerShell/PowerShell/releases/download/v7.2.1/powershell-7.2.1-osx-arm64.tar.gz"
-  @x64url = "https://github.com/PowerShell/PowerShell/releases/download/v7.2.1/powershell-7.2.1-osx-x64.tar.gz"
-  @arm64sha256 = "7478d10fd251cf41950392c5c357ab06e6ce439bc85e1c556ef125750957ec7c"
-  @x64sha256 = "331307ecf7cc28e7ecc7afa7d0ba4527677996fddfc0c08b913bb4b8adcd8c3d"
+  @arm64url = "https://github.com/PowerShell/PowerShell/releases/download/v7.2.2/powershell-7.2.2-osx-arm64.tar.gz"
+  @x64url = "https://github.com/PowerShell/PowerShell/releases/download/v7.2.2/powershell-7.2.2-osx-x64.tar.gz"
+  @arm64sha256 = "d55ccf182273b23fa9fa0dadce51c729757f2941077bc020b445285a92eb4d7d"
+  @x64sha256 = "eee758200657e95da773a0541ada537ef47503b6f54794e68b2e75d7ae94de85"
 
   # We do not specify `version "..."` as 'brew audit' will complain - see https://github.com/Homebrew/legacy-homebrew/issues/32540
   if Hardware::CPU.intel?
@@ -26,11 +26,10 @@ class Powershell < Formula
     sha256 @arm64sha256
   end
 
-  version "7.2.1"
+  version "7.2.2"
   version_scheme 1
 
-  # .NET Core 3.1 requires High Sierra - https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31
-  depends_on macos: :high_sierra
+  depends_on macos: :mojave
 
   def install
     libexec.install Dir["*"]
@@ -56,7 +55,7 @@ class Powershell < Formula
   end
 
   test do
-    assert_equal "7.2.1",
+    assert_equal "7.2.2",
                  shell_output("#{bin}/pwsh -c '$psversiontable.psversion.tostring()'").strip
   end
 end


### PR DESCRIPTION
PowerShell 7.2.2 released on March 16: https://github.com/PowerShell/PowerShell/releases/tag/v7.2.2