### PR TITLE
Fix `permission denied` in write to `/etc/shells`

### DIFF
--- a/Formula/powershell.rb
+++ b/Formula/powershell.rb
@@ -50,7 +50,7 @@ class Powershell < Formula
         brew link --overwrite powershell
 
       If you would like to make PowerShell your default shell, run
-        sudo sh -c "echo '#{bin}/pwsh'  >> /etc/shells"
+        sudo sh -c "echo '#{bin}/pwsh' >> /etc/shells"
         chsh -s #{bin}/pwsh
     EOS
   end

--- a/Formula/powershell.rb
+++ b/Formula/powershell.rb
@@ -50,7 +50,7 @@ class Powershell < Formula
         brew link --overwrite powershell
 
       If you would like to make PowerShell your default shell, run
-        sudo echo '#{bin}/pwsh' >> /etc/shells
+        sudo sh -c "echo '/usr/local/opt/powershell/bin/pwsh'  >> /etc/shells"
         chsh -s #{bin}/pwsh
     EOS
   end

--- a/Formula/powershell.rb
+++ b/Formula/powershell.rb
@@ -50,7 +50,7 @@ class Powershell < Formula
         brew link --overwrite powershell
 
       If you would like to make PowerShell your default shell, run
-        sudo sh -c "echo '/usr/local/opt/powershell/bin/pwsh'  >> /etc/shells"
+        sudo sh -c "echo '#{bin}/pwsh'  >> /etc/shells"
         chsh -s #{bin}/pwsh
     EOS
   end


### PR DESCRIPTION
[Armali explains](https://stackoverflow.com/a/49049781/434034) that the redirect was being tried before sudo:
```
% sudo echo '/usr/local/opt/powershell/bin/pwsh' >> /etc/shells
zsh: permission denied: /etc/shells
```

Slight modification to avoid this, but only tested on macOS Monterey (12.3.1).