### PR TITLE
Update `depends_on` `macos`

### DIFF
--- a/Formula/powershell-daily.rb
+++ b/Formula/powershell-daily.rb
@@ -32,8 +32,9 @@ class PowershellDaily < Formula
   # Disabled because we are unable to maintain the automation to update the formula
   disable! date: "2023-03-03", because: :unmaintained
 
-  # .NET Core 3.1 requires High Sierra - https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31
-  depends_on macos: :high_sierra
+  # .NET 10 RC 1 shipped with macOS 14 (Sonoma) as the minimum supported OS
+  # https://github.com/dotnet/core/blob/v10.0.0-rc.1/release-notes/10.0/supported-os.md#apple
+  depends_on macos: :sonoma
 
   def install
     libexec.install Dir["*"]

--- a/Formula/powershell-lts.rb
+++ b/Formula/powershell-lts.rb
@@ -29,8 +29,9 @@ class PowershellLts < Formula
   version "7.4.11"
   version_scheme 1
 
-  # .NET Core 3.1 requires High Sierra - https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31
-  depends_on macos: :high_sierra
+  # .NET 8 RC 1 shipped with macOS 10.15 (Catalina) as the minimum supported OS
+  # https://github.com/dotnet/core/blob/v8.0.0-rc.1/release-notes/8.0/supported-os.md#apple
+  depends_on macos: :catalina
 
   def install
     libexec.install Dir["*"]

--- a/Formula/powershell-preview.rb
+++ b/Formula/powershell-preview.rb
@@ -33,8 +33,9 @@ class PowershellPreview < Formula
     url :head
   end
 
-  # .NET Core 3.1 requires High Sierra - https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31
-  depends_on macos: :high_sierra
+  # .NET 10 RC 1 shipped with macOS 14 (Sonoma) as the minimum supported OS
+  # https://github.com/dotnet/core/blob/v10.0.0-rc.1/release-notes/10.0/supported-os.md#apple
+  depends_on macos: :sonoma
 
   def install
     libexec.install Dir["*"]

--- a/Formula/powershell.rb
+++ b/Formula/powershell.rb
@@ -29,8 +29,9 @@ class Powershell < Formula
   version "7.5.2"
   version_scheme 1
 
-  # .NET Core 3.1 requires High Sierra - https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31
-  depends_on macos: :high_sierra
+  # .NET 9 RC 1 shipped with macOS 11 (Monterey) as the minimum supported OS
+  # https://github.com/dotnet/core/blob/v9.0.0-rc.1/release-notes/9.0/supported-os.md#apple
+  depends_on macos: :monterey
 
   def install
     libexec.install Dir["*"]


### PR DESCRIPTION
Update macOS `depends_on` to reflect .NET’s supported OS at each release’s ship date.