### PR TITLE
Remove High Sierra dependency for PowerShell LTS

### DIFF
--- a/Formula/powershell-lts.rb
+++ b/Formula/powershell-lts.rb
@@ -29,9 +29,6 @@ class PowershellLts < Formula
   version "7.4.11"
   version_scheme 1
 
-  # .NET Core 3.1 requires High Sierra - https://docs.microsoft.com/en-us/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31
-  depends_on macos: :high_sierra
-
   def install
     libexec.install Dir["*"]
     chmod 0555, libexec/"pwsh"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Remove High Sierra dependency for PowerShell LTS

## PR Context

Homebrew no longer supports specifying minimum macOS versions this way in formulas. The deprecation message explicitly states "There is no replacement" because modern Homebrew expects formulas to work across supported macOS versions without explicit version checks.  All currently supported versions are already later than High Sierra.
