### PR TITLE
Deprecate Homebrew tap in favor of Homebrew Core and signed `.pkg`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,32 @@
 > [!WARNING]
 > **This tap is deprecated and no longer maintained.**
 >
-> PowerShell is now available directly from
-> [Homebrew Core](https://formulae.brew.sh/formula/powershell) as well as
-> through the signed and notarized `.pkg` installers published by the PowerShell
-> project. Please migrate to one of the [recommended installation
-> methods](#recommended-installation) below. The `powershell/tap/*` formulas in
-> this repository no longer work.
+> PowerShell is now available directly from the official, signed and notarized
+> `.pkg` installers published by the PowerShell project, as well as from
+> [Homebrew Core](https://formulae.brew.sh/formula/powershell). Please migrate to
+> one of the [recommended installation methods](#recommended-installation) below.
+> The `powershell/tap/*` formulas in this repository no longer work.
 
 ## Recommended installation
 
+### Official `.pkg` installer (recommended)
+
+The PowerShell project publishes macOS `.pkg` installers for both Apple silicon
+(`arm64`) and Intel (`x64`) Macs. Beginning with the May 2026 releases, these
+packages are **notarized and signed by Microsoft**, so you can download and open
+them directly without bypassing Gatekeeper.
+
+1. Download the `.pkg` for your processor architecture from the
+   [PowerShell releases page](https://github.com/PowerShell/PowerShell/releases).
+2. Double-click the downloaded package and follow the installer prompts.
+
+To update, download and install the newer package. For full instructions —
+including the Gatekeeper workarounds needed for releases prior to May 2026 — see
+[Install PowerShell on macOS](https://learn.microsoft.com/powershell/scripting/install/install-powershell-on-macos).
+
 ### Homebrew (community formula)
 
-PowerShell is published to [Homebrew Core](https://formulae.brew.sh/formula/powershell),
+PowerShell is also published to [Homebrew Core](https://formulae.brew.sh/formula/powershell),
 so you no longer need this tap. Install it with:
 
 ```sh
@@ -52,17 +66,6 @@ brew upgrade powershell
 > Microsoft. See
 > [Alternate ways to install PowerShell](https://learn.microsoft.com/powershell/scripting/install/alternate-install-methods#install-on-macos-using-homebrew)
 > for details.
-
-### Signed and notarized `.pkg` installers (macOS)
-
-Beginning with the May 2026 releases, the macOS `.pkg` packages published by the
-PowerShell project are **notarized and signed by Microsoft**, making them a fully
-supported macOS installation path. Download the package for your processor
-architecture from the [PowerShell releases page](https://github.com/PowerShell/PowerShell/releases)
-and open it to install.
-
-For full instructions, including older-release Gatekeeper workarounds, see
-[Install PowerShell on macOS](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-macos).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,83 +1,76 @@
 # Homebrew tap for PowerShell Products
 
-## Requirements
+> [!WARNING]
+> **This tap is deprecated and no longer maintained.**
+>
+> PowerShell is now available directly from
+> [Homebrew Core](https://formulae.brew.sh/formula/powershell) as well as
+> through the signed and notarized `.pkg` installers published by the PowerShell
+> project. Please migrate to one of the [recommended installation
+> methods](#recommended-installation) below. The `powershell/tap/*` formulas in
+> this repository no longer work.
 
-1. You must be running a version of macOS supported by PowerShell.
-1. See [Homebrew requirements](https://docs.brew.sh/Installation#macos-requirements)
+## Recommended installation
 
-## Fomula List
+### Homebrew (community formula)
 
-### PowerShell Channels
+PowerShell is published to [Homebrew Core](https://formulae.brew.sh/formula/powershell),
+so you no longer need this tap. Install it with:
 
-* [Stable](#powershell-stable)
-* [Preview](#powershell-preview)
-* [LTS](#powershell-lts)
-* [~~Daily~~](#powershell-daily)
-  * Daily is marked as not supported and will only be occasionally update. 
-    Please move to one of the other channels.
-    
-Learn more about using PowerShell ...
-
-Issues can be reported at [PowerShell/PowerShell](https://github.com/PowerShell/PowerShell/issues/new/choose).
-
-## Install Instructions
-
-### PowerShell Stable
-
-```
-brew install powershell/tap/powershell
+```sh
+brew install powershell
 ```
 
-You can now run the `pwsh` to get started.
+If you previously installed PowerShell using the Homebrew cask, you must first
+uninstall the cask before you can successfully install using the Homebrew
+formula:
 
-To upgrade to the latest version, run:
-
+```sh
+# Uninstall the PowerShell cask instance
+brew uninstall --cask powershell
+# Uninstall the PowerShell Preview cask instance
+brew uninstall --cask powershell-preview
 ```
+
+If you receive the message *"Warning: PowerShell is already installed, it's just
+not linked."*, run:
+
+```sh
+brew link powershell
+```
+
+To update PowerShell to the latest release:
+
+```sh
+brew update
 brew upgrade powershell
 ```
 
-### PowerShell Preview
+> [!NOTE]
+> The brew formula is maintained and supported by the Homebrew community. It
+> builds PowerShell from source code rather than installing a package built by
+> Microsoft. See
+> [Alternate ways to install PowerShell](https://learn.microsoft.com/powershell/scripting/install/alternate-install-methods#install-on-macos-using-homebrew)
+> for details.
 
-```
-brew install powershell/tap/powershell-preview
-```
+### Signed and notarized `.pkg` installers (macOS)
 
-You can now run the `pwsh-preview` to get started.
+Beginning with the May 2026 releases, the macOS `.pkg` packages published by the
+PowerShell project are **notarized and signed by Microsoft**, making them a fully
+supported macOS installation path. Download the package for your processor
+architecture from the [PowerShell releases page](https://github.com/PowerShell/PowerShell/releases)
+and open it to install.
 
-To upgrade to the latest version, run:
+For full instructions, including older-release Gatekeeper workarounds, see
+[Install PowerShell on macOS](https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-macos).
 
-```
-brew upgrade powershell-preview
-```
+## Requirements
 
-### PowerShell LTS
+1. You must be running a version of macOS supported by PowerShell.
+1. See [Homebrew requirements](https://docs.brew.sh/Installation#macos-requirements).
 
-```
-brew install powershell/tap/powershell-lts
-```
-
-You can now run the `pwsh-lts` to get started.
-
-To upgrade to the latest version, run:
-
-```
-brew upgrade powershell-lts
-```
-
-
-### PowerShell Daily
-
-```
-brew install powershell/tap/powershell-daily
-```
-
-You can now run the `pwsh-daily` to get started.
-
-To upgrade to the latest version, run:
-
-```
-brew upgrade powershell-daily
-```
+Issues with PowerShell itself can be reported at
+[PowerShell/PowerShell](https://github.com/PowerShell/PowerShell/issues/new/choose).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 > **This tap is deprecated and no longer maintained.**
 >
 > PowerShell is now available directly from the official, signed and notarized
-> `.pkg` installers published by the PowerShell project, as well as from
+> `.pkg` installers published by the [PowerShell project](https://github.com/PowerShell/PowerShell),
+> as well as from
 > [Homebrew Core](https://formulae.brew.sh/formula/powershell). Please migrate to
 > one of the [recommended installation methods](#recommended-installation) below.
 > The `powershell/tap/*` formulas in this repository no longer work.
@@ -13,17 +14,16 @@
 
 ### Official `.pkg` installer (recommended)
 
-The PowerShell project publishes macOS `.pkg` installers for both Apple silicon
-(`arm64`) and Intel (`x64`) Macs. Beginning with the May 2026 releases, these
-packages are **notarized and signed by Microsoft**, so you can download and open
-them directly without bypassing Gatekeeper.
+The [PowerShell project](https://github.com/PowerShell/PowerShell) publishes
+macOS `.pkg` installers for both Apple silicon (`arm64`) and Intel (`x64`) Macs.
+Beginning with the May 2026 releases, these packages are **notarized and signed
+by Microsoft**, so you can download and open them directly.
 
 1. Download the `.pkg` for your processor architecture from the
    [PowerShell releases page](https://github.com/PowerShell/PowerShell/releases).
 2. Double-click the downloaded package and follow the installer prompts.
 
-To update, download and install the newer package. For full instructions —
-including the Gatekeeper workarounds needed for releases prior to May 2026 — see
+To update, download and install the newer package. For full instructions, see
 [Install PowerShell on macOS](https://learn.microsoft.com/powershell/scripting/install/install-powershell-on-macos).
 
 ### Homebrew (community formula)


### PR DESCRIPTION
This tap is broken and unmaintained, and PowerShell is now available directly from [Homebrew Core](https://formulae.brew.sh/formula/powershell) (`brew install powershell`), so there's no reason to keep pointing people here.

- Add a prominent deprecation warning at the top of the README
- Document the recommended install paths:
  - The community Homebrew Core formula, copied from the [updated docs](https://learn.microsoft.com/powershell/scripting/install/alternate-install-methods#install-on-macos-using-homebrew) Sean linked in the issue
  - The macOS `.pkg` installers, which are signed and notarized by Microsoft as of the May 2026 releases and are therefore a fully supported macOS path
- Remove the old `powershell/tap/*` install instructions since those formulas no longer work

Closes #1342.